### PR TITLE
Saqué el destructor del nodo

### DIFF
--- a/Nodo.h
+++ b/Nodo.h
@@ -16,10 +16,6 @@ public:
     // POST: Construye un nodo con el dato recibido
     Nodo(Tipo datoExterno);
 
-    // PRE: El nodo debe estar creado
-    // POST: Libera la memoria del nodo
-    ~Nodo();
-
     // PRE: pSigExterno debe ser valido
     // POST: Le asigna pSigExterno a pSig
     void asignarSiguiente(Nodo* pSigExterno);
@@ -43,11 +39,6 @@ template <typename Tipo>
 Nodo<Tipo>:: Nodo(Tipo datoExterno) {
     dato = datoExterno;
     pSig = 0;
-}
-
-template <typename Tipo>
-Nodo<Tipo>:: ~Nodo() {
-    delete dato;
 }
 
 // <-------------------- Asignaciones


### PR DESCRIPTION
Decidí sacarlo en base a lo que hablamos en la videollamada de hoy. El destructor básicamente se encargaba de liberar la memoria del dato que estaba guardado en el nodo, pero como usamos listas de cosas que no necesariamente están en memoria dinámica (lista de actores, directores, géneros) cuando se llame al destructor va a tirar un error porque son cosas que no se pueden borrar.

**Pendiente:** tenemos que ver en donde liberar la memoria de la Pelicula. El destructor de la lista libera el nodo, pero no la película. Creo que alcanzaría con hacer algo así
```
    for (int i = 0; i < lista.obtenerCantidadElementos(); i ++) {
        delete lista.obtenerDato(i);
    }
```